### PR TITLE
Request data is now compacted before emitting it in event

### DIFF
--- a/test/slot-curate.js
+++ b/test/slot-curate.js
@@ -49,7 +49,6 @@ describe("SlotCurate", () => {
 
       await expect(slotCurate.connect(requester).addItem(...args, { value: VALUE_REQUESTER_STAKE }))
         .to.emit(slotCurate, "ItemAddRequest")
-        .withArgs(...args.slice(0, 4));
     });
 
     it("Should should not let you add an item using an occupied slot.", async () => {


### PR DESCRIPTION
This saves:
~750 gas for `addItem`
~1125 gas for `editItem` and `removeItem`
It costs:
extra work in subgraph
loss of ability to query the events directly. Entirely dependant on subgraph